### PR TITLE
Fix empty list of providers when adding alternative identity

### DIFF
--- a/server/social.coffee
+++ b/server/social.coffee
@@ -403,7 +403,8 @@ module.exports = exports = (log, loga, argv) ->
     app.get '/auth/addAuthDialog', (req, res) ->
       # only makes sense to add alternative authentication scheme if
       # this the user is authenticated
-      if getUser(req)
+      user = getUser(req)
+      if user
         referer = req.headers.referer
 
         currentSchemes = _.keys(user)


### PR DESCRIPTION
Make sure that user is set correctly before we determine the list of alternative identity providers to display.