### PR TITLE
Pass access_token in headers ( fixes #27 )

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "coffeeify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-3.0.1.tgz",
@@ -5003,6 +5008,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "oauth": {
+      "version": "github:FedWiki/node-oauth#ba35bd335862255d7cd31d4701d120bef4ba3578",
+      "from": "github:FedWiki/node-oauth#ba35bd335862255d7cd31d4701d120bef4ba3578"
+    },
     "passport": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
@@ -5025,50 +5034,10 @@
       }
     },
     "passport-github": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
-      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
+      "version": "github:FedWiki/passport-github#70fe99ba7e66422092a19d89f4b1ab1a23eac644",
+      "from": "github:FedWiki/passport-github#70fe99ba7e66422092a19d89f4b1ab1a23eac644",
       "requires": {
-        "passport-oauth2": "1.x.x"
-      },
-      "dependencies": {
-        "base64url": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-          "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
-        },
-        "oauth": {
-          "version": "0.9.15",
-          "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-          "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
-        },
-        "passport-oauth2": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
-          "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
-          "requires": {
-            "base64url": "3.x.x",
-            "oauth": "0.9.x",
-            "passport-strategy": "1.x.x",
-            "uid2": "0.0.x",
-            "utils-merge": "1.x.x"
-          }
-        },
-        "passport-strategy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
-        },
-        "uid2": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-          "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
-        },
-        "utils-merge": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-        }
+        "passport-oauth2": "github:FedWiki/passport-oauth2#9dce46031c1cffb583ac543fbfe990f5df92d850"
       }
     },
     "passport-google-oauth20": {
@@ -5117,6 +5086,22 @@
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         }
       }
+    },
+    "passport-oauth2": {
+      "version": "github:FedWiki/passport-oauth2#9dce46031c1cffb583ac543fbfe990f5df92d850",
+      "from": "github:FedWiki/passport-oauth2#9dce46031c1cffb583ac543fbfe990f5df92d850",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "github:FedWiki/node-oauth#ba35bd335862255d7cd31d4701d120bef4ba3578",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "passport-twitter": {
       "version": "1.0.4",
@@ -5192,6 +5177,16 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
       "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "whatwg-fetch": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "es6-promise": "^4.2.8",
     "lodash": "^4.17.14",
     "passport": "^0.3.2",
-    "passport-github": "^1.1.0",
+    "passport-github": "FedWiki/passport-github#70fe99ba7e66422092a19d89f4b1ab1a23eac644",
     "passport-google-oauth20": "^2.0.0",
     "passport-twitter": "^1.0.4",
     "persona-pass": "^0.2.1",


### PR DESCRIPTION
There appear to be a number of different approaches for addressing the warning from GitHub about the use of a query parameter to pass `access_token`.

The root cause appears to be in `node-oauth`, so I'm going to follow the led of yWorks and fork that repo, together with `passport-oauth2` and `passport-github`, and make the necessary change so that the access token is always passed via a header. This is also what is recommended in [OAuth 2.0 Security Best Current Practice](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-14), and elsewhere.