### PR TITLE
Set isOwner in setup

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -206,6 +206,7 @@ setup = (user) ->
     .then (response) ->
       if response.ok
         response.json().then (json) ->
+          window.isOwner = json.isOwner
           settings = json
           if settings.wikiHost
             dialogHost = settings.wikiHost


### PR DESCRIPTION
After page reload, isOwner sometimes has wrong value. Setting it after
loading client-settings in setup fixes this.