### PR TITLE
Set isOwner true in claim_wiki

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -36,6 +36,7 @@ claim_wiki = () ->
         response.json().then (json) ->
           ownerName = json.ownerName
           window.isClaimed = true
+          window.isOwner = true
           update_footer ownerName, true
       else
         console.log 'Attempt to claim site failed', response


### PR DESCRIPTION
After successfully claiming a wiki the client didn't recognize the wiki
as owned until it was reloaded. With this change, the client recognizes
the wiki is owned immediately upon a successful claim.