### PR TITLE
Add generic OAuth support

### DIFF
--- a/docs/config-oauth2.md
+++ b/docs/config-oauth2.md
@@ -1,0 +1,15 @@
+
+
+```JSON
+{
+  "farm": true,
+  "security_type": "passportjs",
+  "oauth2_clientID": "CLIENT ID",
+  "oauth2_clientSecret": "CLIENT SECRET",
+  "oauth2_AuthorizationURL": "https://auth.example.com/oauth2/authorize",
+  "oauth2_TokenURL": "https://auth.example.com/oauth2/token",
+  "wikiDomains": {
+    "example.wiki": {}
+  }
+}
+```

--- a/docs/config-oauth2.md
+++ b/docs/config-oauth2.md
@@ -1,4 +1,36 @@
+## Generic OAuth 2
 
+### Login provider set-up
+
+Like the other PassportJS login providers, we'll need a separate "OAuth2 Client"
+(others call it an "app", a "product" etc.) for our Federated Wiki instance.
+
+How to do this varies slightly for each provider.
+
+### `config.json`
+
+In general, you will need to specify:
+* `oauth2_clientID` -- some systems generate this for you, others allow you to
+    specify it
+* `oauth2_clientSecret` -- secure key (keep this secret!)
+* `oauth2_AuthorizationURL` and `oauth2_TokenURL` -- from your login provider's documentation
+
+You will also need to specify a callback URL. For some providers, you can add
+this when making a new "OAuth Client" for your wiki, for others you will need to
+specify it with `oauth2_CallbackURL`.
+
+You might also need to tell Federated Wiki how to look up usernames:
+* `oauth2_UserInfoURL` -- from login provider's documentation
+* `oauth2_UsernameField` -- starting with 
+  * `params` for information returned in the original token request, or
+  * `profile` for data returned from `oauth2_UserInfoURL`, if you provided it.
+
+Sometimes, you'll be able to look up the URLs by visiting your provider's
+`/.well-known/openid-configuration` URL in a web browser.
+
+### Examples
+
+#### Nextcloud
 
 ```JSON
 {
@@ -8,8 +40,21 @@
   "oauth2_clientSecret": "CLIENT SECRET",
   "oauth2_AuthorizationURL": "https://auth.example.com/oauth2/authorize",
   "oauth2_TokenURL": "https://auth.example.com/oauth2/token",
-  "wikiDomains": {
-    "example.wiki": {}
-  }
+}
+```
+
+#### Keycloak
+
+```JSON
+{
+  "farm": true,
+  "security_type": "passportjs",
+  "oauth2_clientID": "CLIENT ID",
+  "oauth2_clientSecret": "CLIENT SECRET",
+  "oauth2_AuthorizationURL": "https://auth.example.com/auth/realms/Wiki.Cafe/protocol/openid-connect/auth",
+  "oauth2_TokenURL": "https://auth.example.com/auth/realms/Wiki.Cafe/protocol/openid-connect/token",
+  "oauth2_UserInfoURL": "https://auth.example.com/auth/realms/Wiki.Cafe/protocol/openid-connect/userinfo",
+  "oauth2_CallbackURL": "http://localhost:3000/auth/oauth2/callback",
+  "oauth2_UsernameField": "profile.preferred_username"
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,3 +17,4 @@ See, depending on which identity provider you choose to use:
 * [GitHub](./config-github.md)
 * [Google](./config-google.md)
 * [Twitter](./config-twitter.md)
+* [Generic OAuth](./config-oauth2.md)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "passport": "^0.3.2",
     "passport-github": "github:FedWiki/passport-github#70fe99ba7e66422092a19d89f4b1ab1a23eac644",
     "passport-google-oauth20": "^2.0.0",
+    "passport-oauth2": "^1.6.1",
     "passport-twitter": "^1.0.4",
     "persona-pass": "^0.2.1",
     "qs": "^6.7.0",

--- a/server/social.coffee
+++ b/server/social.coffee
@@ -201,23 +201,42 @@ module.exports = exports = (log, loga, argv) ->
 
       oauth2StrategyName = callbackHost + 'OAuth'
 
+      if argv.oauth2_UserInfoURL?
+        OAuth2Strategy::userProfile = (accesstoken, done) -> 
+          console.log "hello"
+          console.log accesstoken
+          @_oauth2._request "GET", argv.oauth2_UserInfoURL, null, null, accesstoken, (err, data) ->
+            if err
+              return done err 
+            try
+              data = JSON.parse data 
+            catch e
+              return done e
+            done(null, data)
+
       passport.use(oauth2StrategyName, new OAuth2Strategy({
         clientID: argv.oauth2_clientID
         clientSecret: argv.oauth2_clientSecret
         authorizationURL: argv.oauth2_AuthorizationURL
-        tokenURL: argv.oauth2_TokenURL
-        # userURL: argv.oauth2_UserURL
-        # scope: 'user:emails'
-        # callbackURL is optional, and if it exists must match that given in
-        # the OAuth application settings - so we don't specify it.
+        tokenURL: argv.oauth2_TokenURL,
+        # not all providers have a way of specifying the callback URL
+        callbackURL: argv.oauth2_CallbackURL,
+        userInfoURL: argv.oauth2_UserInfoURL
         }, (accessToken, refreshToken, params, profile, cb) ->
+          console.log("accessToken", accessToken)
+          console.log("refreshToken", refreshToken)
           console.log("params", params)
           console.log("profile", profile)
+          if argv.oauth2_UsernameField?
+            username_query = argv.oauth2_UsernameField 
+          else 
+            username_query = 'params.user_id'
           user.oauth2 = {
-            id: params.user_id,
-            username: params.user_id,
-            displayName: params.user_id,
+            id: eval username_query,
+            username: eval username_query
+            displayName: eval username_query
           }
+          console.log user.oauth2
           cb(null, user)))
 
     # Github Strategy


### PR DESCRIPTION
Testing plan:
1. Create a new OAuth 2.0 client in an existing provider (even the existing Google, Github, Twitter would work for this)
2. Look up the provider's "authorize" and "token" URLs
3. Update your wiki `config.json` following  the example in `docs/config-oauth2.md`
4. Start (or restart) fedwiki
5. Click the padlock, then the "OAuth2" login button