### PR TITLE
Updating login to view

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -31,10 +31,13 @@ claim_wiki = () ->
     .then (response) ->
       if response.ok
         response.json().then (json) ->
-          ownerName = json.ownerName
-          window.isClaimed = true
-          window.isOwner = true
-          update_footer ownerName, true
+          if wiki.lineup.bestTitle() is 'Login Required'
+            location.reload()
+          else
+            ownerName = json.ownerName
+            window.isClaimed = true
+            window.isOwner = true
+            update_footer ownerName, true
       else
         console.log 'Attempt to claim site failed', response
 
@@ -103,7 +106,10 @@ update_footer = (ownerName, isAuthenticated) ->
             if !isClaimed
               claim_wiki()
             else
-              update_footer ownerName, true)
+              if wiki.lineup.bestTitle() is 'Login Required'
+                location.reload()
+              else
+                update_footer ownerName, true)
 
 
 
@@ -165,8 +171,6 @@ setup = (user) ->
         settings.dialogURL = dialogProtocol + '//' + dialogHost + '/auth/loginDialog'
         settings.relayURL = dialogProtocol + '//' + dialogHost + '/auth/relay.html'
         settings.dialogAddAltURL = dialogProtocol + '//' + dialogHost + '/auth/addAuthDialog'
-
-
         update_footer ownerName, isAuthenticated
     else
       console.log 'Unable to fetch client settings: ', response

--- a/server/social.coffee
+++ b/server/social.coffee
@@ -400,15 +400,17 @@ module.exports = exports = (log, loga, argv) ->
         false
 
       app.all '*', (req, res, next) ->
-        # todo: think about assets??
-        return next() unless /\.(json|html)$/.test req.url
+        # everything is restricted except site flag,
+        return next() if req.url is '/favicon.png'
+        return next() unless /\.(json|html)$/.test req.url or req.url.startsWith('/assets')
 
         # prepare to examine remote server's forwarded session
         res.header 'Access-Control-Allow-Origin', req.get('Origin')||'*'
         res.header 'Access-Control-Allow-Credentials', 'true'
-        return next() if isAuthorized(req) || allowedToView(req)
+        # protect unclaimed by adding "add owner isnt ''" - maybe via parameter
+        return next() if isAuthorized(req) or allowedToView(req)
         return res.redirect("/view/#{m[1]}") if m = req.url.match /\/(.*)\.html/
-        return res.json([]) if req.url == '/system/sitemap.json'
+        return res.json(['Login Required']) if req.url == '/system/sitemap.json'
 
         # not happy, explain why these pages can't be viewed
         problem = "This is a restricted wiki requires users to login to view pages. You do not have to be the site owner but you do need to login with a participating email address."


### PR DESCRIPTION
Some improvements for login in to view.

Lineup is reloaded after login, so user is not left with a 'Login to View' page after they have logged in.

All wiki content except the favicon is now protected, this includes assets.

NOTE: As before, unclaimed wiki can be edited. Maybe this should be prevented, or behind config.