### PR TITLE
Add support for OAuth2 authentication against MediaWiki installs

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,7 +4,8 @@ This security plug-in is written as a replacement for the Mozilla Persona plugin
 
 *To allow an orderly migration of wiki site ownership this plug-in makes use of the Mozilla Persona plug-in for Passport. This is only presented as a login option on those wiki sites that have already been claimed using Mozilla Persona. When you login with Mozilla Persona there will be a link that allows you to add an alternative identity from those the site owner has configured.*
 
-In this release we make use of Passport's OAuth plug-ins for GitHub, Google, and Twitter. 
+In this release we make use of Passport's OAuth plug-ins for GitHub,
+Google, Twitter, and MediaWiki.
 
 As a wiki farm host, you have to choose which authentication provider you want to use. You will need to register an application with the required identity provider, and configure the wiki server. See, [configuring wiki-security-passportjs](./docs/configuration.md). 
 

--- a/docs/config-oauth2.md
+++ b/docs/config-oauth2.md
@@ -21,6 +21,8 @@ specify it with `oauth2_CallbackURL`.
 
 You might also need to tell Federated Wiki how to look up usernames:
 * `oauth2_UserInfoURL` -- from login provider's documentation
+  * If this endpoint expects an HTTP Authorization header (instead of
+    a token in the query string) set `oauth2_UseHeader` to `true`.
 * `oauth2_IdField`, `oauth2_DisplayNameField`, `oauth2_UsernameField` -- starting with 
   * `params` for information returned in the original token request, or
   * `profile` for data returned from `oauth2_UserInfoURL`, if you provided it.

--- a/docs/config-wikimedia.md
+++ b/docs/config-wikimedia.md
@@ -1,0 +1,73 @@
+## Wikimedia
+
+MediaWiki instances running
+[Extension:OAuth](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:OAuth),
+including all Wikimedia wikis (like Wikipedia), can be used as an
+OAuth authentication source.
+
+### Register an application with Wikimedia
+
+* Review the [OAuth app
+  guidelines](https://meta.wikimedia.org/wiki/OAuth_app_guidelines) on
+  meta.wikimedia.org.
+* As described on that page, propose a new client registration at
+  [Special:OAuthConsumerRegistration/propose](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose).
+  Use the "Propose an OAuth 2.0 client" link.
+* Provide your wiki details:
+** An application name; presumably the name of your wiki.  If you
+   include "test" in the name or "localhost" in the callback URL
+   the authorization will work only on your own account and only
+   for 30 days.
+** Set the Consumer version to `1.0`
+** Describe your application; you might want to mention that the
+   software is open-source and available at
+   https://github.com/fedwiki/wiki-security-passportjs/
+** You can click "This consumer is for use only by..." if this will
+   be a single-user wiki.
+** You will need to specify a callback URL.  For local testing this
+   will be http://localhost:3000/auth/oauth2/callback but for a wiki
+   visible to the external internet you will need to update the host
+   portion.  This is a callback provided by `wiki-security-passport`.
+** You will need an "Authorization code" grant type, and probably a
+   "Refresh token" grant as well; you don't need "Client credentials".
+** You will probably check "User identity verification only", either
+   with "access to real name..." if you want to use the
+   `oauth2_DisplayNameField` feature or without that otherwise.
+   "Request authorization for specific permissions" is only needed if
+   you are working on a deeper integration with MediaWiki.
+
+When you click on "Propose registration" you will get a client
+application key and client application secret which you will use
+to create a `config.json`.  Note that you can access the details
+of your registration later at
+[Special:OAuthConsumerRegistration/list](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/list).
+
+### Configure Wiki
+
+The Wiki is configured by adding the `Consumer Key` and `Consumer Secret` to the configuration. As long as we have not selected `Enable Callback Locking` these can be added outside the `wikiDomains` definition, so they apply to the entire farm. The `wikiDomains` definition is required so that the security plugin knows what is required.
+
+This example will work for a test server running on `localhost:3000`:
+```JSON
+{
+	"admin": {"oauth2": "ID VALUE FROM OWNER.JSON FILE OF ADMIN"},
+	"security_type": "passportjs",
+	"oauth2_clientID": "CLIENT APPLICATION ID",
+	"oauth2_clientSecret": "CLIENT APPLICATION SECRET",
+	"oauth2_CallbackURL": "http://localhost:3000/auth/oauth2/callback",
+	"oauth2_AuthorizationURL": "https://www.mediawiki.org/w/rest.php/oauth2/authorize",
+	"oauth2_TokenURL": "https://www.mediawiki.org/w/rest.php/oauth2/access_token",
+	"oauth2_UserInfoURL": "https://www.mediawiki.org/w/rest.php/oauth2/resource/profile",
+	"oauth2_UseHeader": true,
+	"oauth2_IdField": "profile.sub",
+	"oauth2_DisplayNameField": "profile.realname",
+	"oauth2_UsernameField": "profile.username",
+	"wikiDomains": {
+		"localhost": {}
+	}
+}
+```
+
+Note that Wikimedia wikis (the global user accounts on mediawiki.org)
+don't export "realname".  If you are running against a local mediawiki
+instance you will need to update the `https://www.media.org/w/` prefix
+to match your local install.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,4 +17,5 @@ See, depending on which identity provider you choose to use:
 * [GitHub](./config-github.md)
 * [Google](./config-google.md)
 * [Twitter](./config-twitter.md)
+* [Wikimedia](./config-wikimedia.md)
 * [Generic OAuth](./config-oauth2.md)

--- a/server/social.coffee
+++ b/server/social.coffee
@@ -15,7 +15,6 @@ https = require 'https'
 url = require 'url'
 
 _ = require 'lodash'
-glob = require 'glob'
 
 passport = require('passport')
 
@@ -166,7 +165,8 @@ module.exports = exports = (log, loga, argv) ->
         OAuth2Strategy::userProfile = (accesstoken, done) -> 
           console.log "hello"
           console.log accesstoken
-          @_oauth2._request "GET", argv.oauth2_UserInfoURL, null, null, accesstoken, (err, data) ->
+          @_oauth2.useAuthorizationHeaderforGET argv.oauth2_UseHeader?
+          @_oauth2.get argv.oauth2_UserInfoURL, accesstoken, (err, data) ->
             if err
               return done err 
             try


### PR DESCRIPTION
This uses [[Extension:OAuth]], which is installed on Wikimedia wikis.
