### PR TITLE
Fix OAuth callback URLs missing port in farm mode

### DIFF
--- a/server/social.coffee
+++ b/server/social.coffee
@@ -48,8 +48,9 @@ module.exports = exports = (log, loga, argv) ->
 
   if wikiHost
     callbackHost = wikiHost
-    if url.parse(argv.url).port
-      callbackHost = callbackHost + ":" + url.parse(argv.url).port
+    # In farm mode, argv.url loses port info, so use argv.port directly
+    if argv.port and argv.port != 80
+      callbackHost = callbackHost + ":" + argv.port
   else
     callbackHost = url.parse(argv.url).host
 


### PR DESCRIPTION
In farm mode, argv.url gets stripped of port information by the farm logic, causing OAuth callback URLs to be constructed without the port number. This results in authentication failures when the wiki is running on non-standard ports.

For example:
- Before: http://localhost/auth/oauth2/callback (fails with connection refused)
- After: http://localhost:3000/auth/oauth2/callback (works correctly)

The fix preserves the port by using argv.port directly when in farm mode, while maintaining backward compatibility for non-farm deployments.