### PR TITLE
Catches syntax errors in the owner.json file

### DIFF
--- a/server/social.coffee
+++ b/server/social.coffee
@@ -64,7 +64,12 @@ module.exports = exports = (log, loga, argv) ->
       if exists
         fs.readFile(idFile, (err, data) ->
           if err then return cb err
-          owner = JSON.parse(data)
+          try
+            owner = JSON.parse(data)
+          catch parseError
+            console.error "Error parsing owner file #{idFile}", parseError
+            owner = {name: "syntax error", friend: {secret: null}}
+            return cb()
           cb())
       else
         owner = ''


### PR DESCRIPTION
When wiki tries to retrieve the owner for a site, if there is a syntax error in the owner.json, it will crash the whole farm.

This change adds a bit of graceful degradation. An ill-formed owner file won't crash the farm, and this adds a error notification into the wiki client footer, and also into the wiki logs.